### PR TITLE
Read version + name from pom.xml for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ VOLUME /tmp
 EXPOSE 8080
 
 # The application's jar file
-#ARG JAR_FILE=target/canada-holidays-api-1.0.0.jar
 ARG JAR_FILE=target/$FILENAME.jar
 
 # Add the application's jar to the container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Start with a base image containing Java runtime
 FROM openjdk:11-jdk-slim
 
+ARG FILENAME
+
 # Add Maintainer Info
 LABEL maintainer="paul.craig@cds-snc.ca"
 
@@ -11,7 +13,8 @@ VOLUME /tmp
 EXPOSE 8080
 
 # The application's jar file
-ARG JAR_FILE=target/canada-holidays-api-1.0.0.jar
+#ARG JAR_FILE=target/canada-holidays-api-1.0.0.jar
+ARG JAR_FILE=target/$FILENAME.jar
 
 # Add the application's jar to the container
 ADD ${JAR_FILE} app.jar

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+version="$(xpath pom.xml //project/version/text\(\))"
+artifactId="$(xpath pom.xml //project/artifactId/text\(\))"
 
-docker build -t holidays .
+docker build --build-arg FILENAME=$artifactId-$version -t holidays .

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>ca.pcraig3</groupId>
 	<artifactId>public-holidays-in-canada-api</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<name>holidays-canada</name>
 	<description>API for the Public holidays in Canada, as listed on Wikipedia: https://en.wikipedia.org/wiki/Public_holidays_in_Canada</description>
 


### PR DESCRIPTION
This should read the version # + artifactId from the pom.xml file and use that for the .jar filename.

Note: We'll need to move this over to a CDS repo to if we want to automate the deployment with Google cloud.